### PR TITLE
Remove statement re example of user-level scopes

### DIFF
--- a/authorization/scopes-and-launch-context/index.md
+++ b/authorization/scopes-and-launch-context/index.md
@@ -63,7 +63,7 @@ Goal | Scope | Notes
 -----|-------|-----
 Read a feed of all new lab observations across a patient population: | `user/Observation.read` |
 Manage all appointments to which the authorizing user has access | `user/Appointment.read` `user/Appointment.write` | Note that `read` and `write` both need to be supplied. (Write access does not imply read access.)
-Manage all resources on behalf of the authorizing user| `user/*.read` `user/*.write `| Note that the permission is broader than our goal: with this scope, an app can add not only blood pressures, but other observations as well.
+Manage all resources on behalf of the authorizing user| `user/*.read` `user/*.write `| 
 
 
 ## Scopes for requesting context data


### PR DESCRIPTION
The removed statement does not apply to this particular example - it is a cut-and-paste from one of the patient-specific code [See example of scope/permission to allow updates to a patient's blood pressure](https://github.com/jbenhamou/smart-on-fhir.github.io/blob/master/authorization/scopes-and-launch-context/index.md#patient-specific-scopes).
